### PR TITLE
Various config options & Debian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ None.
                  - "{{ ansible_default_ipv4.address }}"
                track_scripts:
                  - check_haproxy
+               raw_config:
+                 - 'mcast_src_ip @IP'
 
 ## Author Information
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ None.
                  - "{{ ansible_default_ipv4.address }}"
                track_scripts:
                  - check_haproxy
+               track_interfaces:
+                 - eth1
                raw_config:
                  - 'mcast_src_ip @IP'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for keepalived
 
-keepalived_global: []
-keepalived_vrrp_sync_groups: []
-keepalived_vrrp_scripts: []
-keepalived_vrrp_instances: []
+keepalived_global: {}
+keepalived_vrrp_sync_groups: {}
+keepalived_vrrp_scripts: {}
+keepalived_vrrp_instances: {}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,10 @@ galaxy_info:
     - 6
     - 7
   categories:
+  - name: Debian
+    versions:
+    - jessie
+  categories:
   - networking
   - system
   - web

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,6 @@ galaxy_info:
     versions:
     - 6
     - 7
-  categories:
   - name: Debian
     versions:
     - jessie

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,10 @@
   include_vars: "{{ ansible_os_family }}.yml"
 
 # Setup/install tasks.
+- include: setup-Debian.yml
+  when: ansible_os_family == 'Debian'
+
+# Setup/install tasks.
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,0 +1,8 @@
+---
+# tasks file for Debian
+
+- name: Install keepalived.
+  apt: name=keepalived state=present
+
+- name: Ensure keepalived is started and enabled on boot.
+  service: name=keepalived enabled=yes

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -64,6 +64,13 @@ vrrp_instance {{ name }} {
 {% endfor %}
     }
 {% endif %}
+{% if instance.track_interfaces is defined %}
+    track_interface {
+{% for track_interface in instance.track_interfaces %}
+      {{ track_interface }}
+{% endfor %}
+    }
+{% endif %}
 
 {% if instance.raw_config is defined %}
 {% for line in instance.raw_config %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -48,7 +48,7 @@ vrrp_instance {{ name }} {
 {% endif %}
 {% if instance.auth_pass is defined %}
     authentication {
-      auth_type PASS
+      auth_type {{ instance.auth_type | default("PASS") }}
       auth_pass {{ instance.auth_pass }}
     }
 {% endif %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -65,5 +65,11 @@ vrrp_instance {{ name }} {
     }
 {% endif %}
 
+{% if instance.raw_config is defined %}
+{% for line in instance.raw_config %}
+      {{ line }}
+{% endfor %}
+{% endif %}
+
 }
 {% endfor %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,2 @@
+---
+# vars file RedHat


### PR DESCRIPTION
This PR adds:

- support for Debian Jessie, essentially just the apt-package task
- The `track_interface` option in the `vrrp_instance` section
- A `raw_config` field in the `vrrp_instance` section
- A `auth_type` field in the `vrrp_instance` section